### PR TITLE
[WIP] Flagging items for discussion around "available" software

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -390,10 +390,10 @@ The source code must be sufficient to reproduce the results of the submission, g
 
 |===
 | Source | Possible method | Considered “Available” for Category purposes (see later section)
-| Included in the submission | Source code | Yes
-| Build from anysupportedpublic Github repo | Commit hash | Yes
-| Built from a public Github repo plus a PR | Commit hash, PR number | Yes
-| Availablebinary (could be free to download or for purchase / customers only) | Name, version, url | Yes
+| Included in the submission | Source code | Yes, if software exactly corresponds to a Beta or Production release of that component
+| Build from anysupportedpublic Github repo | Commit hash | Yes, if commit exactly corresponds to a Beta or Production release of the repo
+| Built from a public Github repo plus a PR | Commit hash, PR number | No
+| Availablebinary (could be free to download or for purchase / customers only) | Name, version, url | Yes, if the binary is a Beta or Production release
 | Built from an internal source control system | Unique source identifier | No
 | Private binary | Checksum | No
 |===

--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -390,10 +390,10 @@ The source code must be sufficient to reproduce the results of the submission, g
 
 |===
 | Source | Possible method | Considered “Available” for Category purposes (see later section)
-| Included in the submission | Source code | Yes, if software exactly corresponds to a Beta or Production release of that component
-| Build from anysupportedpublic Github repo | Commit hash | Yes, if commit exactly corresponds to a Beta or Production release of the repo
-| Built from a public Github repo plus a PR | Commit hash, PR number | No
-| Availablebinary (could be free to download or for purchase / customers only) | Name, version, url | Yes, if the binary is a Beta or Production release
+| Included in the submission | Source code | Yes
+| Build from anysupportedpublic Github repo | Commit hash | Yes (if commit exactly corresponds to a Beta or Production release of the repo??)
+| Built from a public Github repo plus a PR | Commit hash, PR number | Yes (??)
+| Availablebinary (could be free to download or for purchase / customers only) | Name, version, url | Yes
 | Built from an internal source control system | Unique source identifier | No
 | Private binary | Checksum | No
 |===


### PR DESCRIPTION
Flagging items that don't match our current understanding of the rules around "available" software for open source components.

Probably should be dealt with after v0.7.
