### PR TITLE
Compliance tests for Open only by Review Committee's request

### DIFF
--- a/submission_rules.adoc
+++ b/submission_rules.adoc
@@ -471,7 +471,9 @@ This section in progress [TODO].
 
 #### Inference
 
-Refer to the documentation found under https://github.com/mlperf/inference/tree/master/v0.7/compliance/nvidia
+Submissions to the Closed division must include compliance testing results. Please refer to the documentation found under https://github.com/mlperf/inference/tree/master/compliance/nvidia.
+
+Submissions to the Open division need to provide compliance testing results only if requested by the Review Committee.
 
 
 ## Review


### PR DESCRIPTION
As [agreed](https://docs.google.com/presentation/d/1urn23orVQq5Z5Jz8ZJf_o1dASlhIWDSLYi2fyuEY4hw/edit#slide=id.g915930d977_0_0) at Submitters' WG meeting on 1/Sep/2020:

> WG: compliance tests for open submission by review committee request only
